### PR TITLE
Fix second save

### DIFF
--- a/blog.js
+++ b/blog.js
@@ -16,16 +16,16 @@ var simply = (function(simply) {
                 if (typeof a.value['date'] === 'string' && typeof b.value['date'] === 'string') {
                     a = Date.parse(a.value['date']);
                     b = Date.parse(b.value['date']);
-                    return a<b;
+                    return a<b ? 1 : -1;
                 } else if (typeof a.value['date']['value'] != 'undefined') {
-                    return (a.value['date']['value'] < b.value['date']['value']);
+                    return (a.value['date']['value'] < b.value['date']['value']) ? 1 : -1;
                 } else if (a.value['date']['year']==b.value['date']['year']) {
                     if (a.value['date']['month']==b.value['date']['month']) {
-                        return ( parseInt(a.value['date']['day']) < parseInt(b.value['date']['day']));
+                        return ( parseInt(a.value['date']['day']) < parseInt(b.value['date']['day'])) ? 1 : -1;
                     }
-                    return (options.months.indexOf(a.value['date']['month']) < options.months.indexOf(b.value['date']['month']));
+                    return (options.months.indexOf(a.value['date']['month']) < options.months.indexOf(b.value['date']['month']))? 1 : -1;
                 }
-                return (parseInt(a.value['date']['year']) < parseInt(b.value['date']['year']));
+                return (parseInt(a.value['date']['year']) < parseInt(b.value['date']['year']))? 1 : -1;
             }
         }
         if (!options.max) {

--- a/blog.js
+++ b/blog.js
@@ -71,7 +71,6 @@ var simply = (function(simply) {
                 window.setTimeout(function() {
                     var stashedFields = stash.list.querySelectorAll("[data-simply-stashed]");
                     stash.list.removeAttribute("data-simply-stashed");
-                    console.log(stashedFields);
                     for (i=0; i<stashedFields.length; i++) {
                             stashedFields[i].removeAttribute("data-simply-stashed");
                     }

--- a/blog.js
+++ b/blog.js
@@ -68,6 +68,14 @@ var simply = (function(simply) {
                     }
                 }
                 editor.data.stash();
+                window.setTimeout(function() {
+                    var stashedFields = stash.list.querySelectorAll("[data-simply-stashed]");
+                    stash.list.removeAttribute("data-simply-stashed");
+                    console.log(stashedFields);
+                    for (i=0; i<stashedFields.length; i++) {
+                            stashedFields[i].removeAttribute("data-simply-stashed");
+                    }
+                });
             }
         });
     };

--- a/blog.js
+++ b/blog.js
@@ -55,12 +55,12 @@ var simply = (function(simply) {
                 // this is called before the data.json is saved, so we
                 // can update the editor.currentData here to save
                 // changes. The datasource itself will not be saved
-				let documentPath = editor.data.getDataPath(document);
+                let documentPath = editor.data.getDataPath(document);
                 for (var i=0,l=stash.data.length; i<l; i++) {
-					let path = stash.data[i]['data-simply-path'];
-					if (path == documentPath) {
-						continue;
-					}
+		    let path = stash.data[i]['data-simply-path'];
+		    if (path == documentPath) {
+                        continue;
+                    }
                     for ( var key in stash.data[i] ) {
                         if (key!='data-simply-path') {
                             editor.currentData[path][key] = stash.data[i][key];


### PR DESCRIPTION
This PR adds a bit of code to remove the 'data-simply-stashed' markers from the datasources. It fixes a bug where the first est of changes would be saved correctly, but the second set of changes would not be picked up by the save action.